### PR TITLE
More background on Siri female voice recognition issue

### DIFF
--- a/slides.html
+++ b/slides.html
@@ -326,7 +326,7 @@
 
       ## 1. Without women and underrepresented groups, AI can have terrible consequences: 
 
-      - When Siri was first introduced into the iPhone it was not able to understand women's voices because it had only been trained with male voices. 
+      - When Siri was first introduced into the iPhone it was not able to understand women's voices because it had not been tuned to recognize higher pitch voices which women typically have. The developers of the speech recognition engine Siri uses programmed their own biases into the algorithms, as older men they were sufferring from high frequency hearing loss. This is why it's so important to employe diverse teams of software developers.
       - An AI system designed by Northpointe in the US to predict the likelihood that an alleged offender will commit another crime in the future was shown to demonstrate racial bias in its predictions.
     </script>
   </section>


### PR DESCRIPTION
Hey, please feel free to ignore this PR as it is probably too wordy but I thought you may be interested in a bit of the background. 

I used to work in Speech Recognition and I still do presentations on it from time to time and the issue where recognition rates for women are low has been a problem since day one. Imagine a bunch of engineers, probably all men, were working on a way of recognizing speech; they created their algorithms and started training it with data they selected. 

Of course if those engineers couldn't recognize the speech easily they did not feed those utterances into their engine. The problem is most of these engineers were men and likely were suffering from various levels of high-frequency hearing loss. 

Men and women have different pitched voices because of the length and thickness of their vocal cords. This leads to women having higher pitched voices, typically. 

Engineers included an unconscious bias by excluding utterances they could not hear well which means less utterances by females were not included in the training data. So from the very beginning speech recognition engines were improperly tuned and had a hard time recognizing the female voice.

I use this example when I'm talking to people to implore them to hire diverse teams and don't get stuck on a one gender, age, nationality, etc.

Anyway, I thought you might be interested in the history of all this. Feel free to ignore me, I can talk about speech rec all day.